### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Injector/DependencyFinder.php
+++ b/lib/Horde/Injector/DependencyFinder.php
@@ -58,8 +58,11 @@ class Horde_Injector_DependencyFinder
     public function getParameterDependency(Horde_Injector $injector,
                                            ReflectionParameter $parameter)
     {
-        if ($parameter->getClass()) {
-            return $injector->getInstance($parameter->getClass()->getName());
+        $class = $parameter->getType() && !$parameter->getType()->isBuiltin()
+            ? new ReflectionClass($parameter->getType()->getName())
+            : null;
+        if ($class) {
+            return $injector->getInstance($class->getName());
         } elseif ($parameter->isOptional()) {
             return $parameter->getDefaultValue();
         }

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
  <name>Horde_Injector</name>
  <channel>pear.horde.org</channel>
  <summary>Dependency injection container library</summary>
- <description>A depedency injection container for Horde.</description>
+ <description>A dependency injection container for Horde.</description>
  <lead>
   <name>Chuck Hagenbuch</name>
   <user>chuck</user>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Injector/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Injector/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Injector Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Injector/Binder/ClosureTest.php
+++ b/test/Horde/Injector/Binder/ClosureTest.php
@@ -48,6 +48,7 @@ class Horde_Injector_Binder_ClosureTest extends Horde_Test_Case
     }
 }
 
+#[\AllowDynamicProperties]
 class ClosureInjectorMockTestAccess extends Horde_Injector
 {
     public function createChildInjector()

--- a/test/Horde/Injector/Binder/FactoryTest.php
+++ b/test/Horde/Injector/Binder/FactoryTest.php
@@ -79,6 +79,7 @@ class Horde_Injector_Binder_FactoryTest extends Horde_Test_Case
     }
 }
 
+#[\AllowDynamicProperties]
 class InjectorFactoryTestMockFactory
 {
     public function getInjector()
@@ -90,6 +91,8 @@ class InjectorFactoryTestMockFactory
         $this->_injector = $injector;
     }
 }
+
+#[\AllowDynamicProperties]
 class InjectorMockTestAccess extends Horde_Injector
 {
     public function createChildInjector()

--- a/test/Horde/Injector/Binder/ImplementationTest.php
+++ b/test/Horde/Injector/Binder/ImplementationTest.php
@@ -1,7 +1,7 @@
 <?php
 class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->df = new Horde_Injector_DependencyFinder();
     }
@@ -49,11 +49,9 @@ class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
         );
     }
 
-    /**
-     * @expectedException Horde_Injector_Exception
-     */
     public function testShouldThrowExceptionWhenTryingToCreateInstanceOfClassWithUntypedDependencies()
     {
+        $this->expectException('Horde_Injector_Exception');
         $implBinder = new Horde_Injector_Binder_Implementation(
             'Horde_Injector_Binder_ImplementationTest__UntypedDependency',
             $this->df
@@ -74,11 +72,9 @@ class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
         $this->assertEquals('DEPENDENCY', $createdInstance->dep);
     }
 
-    /**
-     * @expectedException Horde_Injector_Exception
-     */
     public function testShouldThrowExceptionIfRequestedClassIsNotDefined()
     {
+        $this->expectException('Horde_Injector_Exception');
         $implBinder = new Horde_Injector_Binder_Implementation(
             'CLASS_DOES_NOT_EXIST',
             $this->df
@@ -87,11 +83,9 @@ class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
         $implBinder->create($this->_getInjectorNeverCallMock());
     }
 
-    /**
-     * @expectedException Horde_Injector_Exception
-     */
     public function testShouldThrowExceptionIfImplementationIsAnInterface()
     {
+        $this->expectException('Horde_Injector_Exception');
         $implBinder = new Horde_Injector_Binder_Implementation(
             'Horde_Injector_Binder_ImplementationTest__Interface',
             $this->df
@@ -100,11 +94,9 @@ class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
         $implBinder->create($this->_getInjectorNeverCallMock());
     }
 
-    /**
-     * @expectedException Horde_Injector_Exception
-     */
     public function testShouldThrowExceptionIfImplementationIsAnAbstractClass()
     {
+        $this->expectException('Horde_Injector_Exception');
         $implBinder = new Horde_Injector_Binder_Implementation(
             'Horde_Injector_Binder_ImplementationTest__AbstractClass',
             $this->df

--- a/test/Horde/Injector/Binder/ImplementationTest.php
+++ b/test/Horde/Injector/Binder/ImplementationTest.php
@@ -1,4 +1,5 @@
 <?php
+#[\AllowDynamicProperties]
 class Horde_Injector_Binder_ImplementationTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Injector/InjectorTest.php
+++ b/test/Horde/Injector/InjectorTest.php
@@ -1,9 +1,11 @@
 <?php
-class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
+class Horde_Injector_InjectorTest extends Horde_Test_Case
 {
     public function testShouldGetDefaultImplementationBinder()
     {
-        $topLevel = $this->getMock('Horde_Injector_TopLevel', array('getBinder'));
+        $topLevel = $this->getMockBuilder('Horde_Injector_TopLevel')
+                         ->setMethods(array('getBinder'))
+                         ->getMock();
         $topLevel->expects($this->once())
             ->method('getBinder')
             ->with($this->equalTo('UNBOUND_INTERFACE'))
@@ -42,20 +44,16 @@ class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
             $injector->getBinder('BOUND_INTERFACE'));
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testShouldThrowExceptionIfInterfaceNameIsNotPassedToMagicFactoryMethodForBinderAddition()
     {
+        $this->expectException('BadMethodCallException');
         $injector = new Horde_Injector($this->_getTopLevelNeverCalledMock());
         $injector->bindMock();
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testShouldThrowExceptionIfMethodNameIsInvalid()
     {
+        $this->expectException('BadMethodCallException');
         $injector = new Horde_Injector($this->_getTopLevelNeverCalledMock());
         $injector->invalid();
     }
@@ -159,7 +157,9 @@ class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
      */
     public function testChildInjectorsDoNotAskParentForInstanceIfBindingIsSet()
     {
-        $mockTopLevel = $this->getMock('Horde_Injector_TopLevel', array('getInstance'));
+        $mockTopLevel = $this->getMockBuilder('Horde_Injector_TopLevel')
+                             ->setMethods(array('getInstance'))
+                             ->getMock();
         $mockTopLevel->expects($this->never())->method('getInstance');
         $injector = new Horde_Injector($mockTopLevel);
 
@@ -169,8 +169,9 @@ class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
 
     public function testChildInjectorAsksParentForInstance()
     {
-        $topLevelMock = $this->getMock('Horde_Injector_TopLevel', array('getInstance'));
-
+        $topLevelMock = $this->getMockBuilder('Horde_Injector_TopLevel')
+                             ->setMethods(array('getInstance'))
+                             ->getMock();
         $topLevelMock->expects($this->once())
             ->method('getInstance')
             ->with('StdClass');
@@ -225,7 +226,10 @@ class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
 
     public function testShouldAllowChildInjectorsAccessToParentInjectorBindings()
     {
-        $mockInjector = $this->getMock('Horde_Injector_TopLevel', array('getBinder'));
+        $mockInjector = $this->getMockBuilder('Horde_Injector_TopLevel')
+                             ->setMethods(array('getBinder'))
+                             ->getMock();
+
         $mockInjector->expects($this->any()) // this gets called once in addBinder
             ->method('getBinder')
             ->with('BOUND_INTERFACE')
@@ -240,7 +244,9 @@ class Horde_Injector_InjectorTest extends PHPUnit_Framework_TestCase
 
     private function _getTopLevelNeverCalledMock()
     {
-        $topLevel = $this->getMock('Horde_Injector_TopLevel', array('getBinder', 'getInstance'));
+        $topLevel = $this->getMockBuilder('Horde_Injector_TopLevel')
+                         ->setMethods(array('getBinder', 'getInstance'))
+                         ->getMock();
         $topLevel->expects($this->never())->method('getBinder');
         return $topLevel;
     }


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-injector/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian change: Add 1011_php8.1.patch. https://salsa.debian.org/horde-team/php-horde-injector/-/blob/debian-sid/debian/patches/1011_php8.1.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-injector/-/blob/debian-sid/debian/patches/1012_php8.2.patch
- Debian change: Spelling fix in packages.xml (used in d/control's LONG_DESCRIPTION). https://salsa.debian.org/horde-team/php-horde-injector/-/blob/debian-sid/debian/patches/2001_spelling-fix-in-packages-xml.patch
